### PR TITLE
AVRO-3760: [python] Fix resolution of future enum with default symbol

### DIFF
--- a/lang/py/avro/io.py
+++ b/lang/py/avro/io.py
@@ -89,17 +89,7 @@ import datetime
 import decimal
 import struct
 import warnings
-from typing import (
-    IO,
-    Deque,
-    Generator,
-    Iterable,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Union,
-)
+from typing import IO, Generator, Iterable, List, Mapping, Optional, Sequence, Union
 
 import avro.constants
 import avro.errors
@@ -776,6 +766,9 @@ class DatumReader:
         # read data
         index_of_symbol = decoder.read_int()
         if index_of_symbol >= len(writers_schema.symbols):
+            default = writers_schema.default
+            if default is not None:
+                return default
             raise avro.errors.SchemaResolutionException(
                 f"Can't access enum index {index_of_symbol} for enum with {len(writers_schema.symbols)} symbols", writers_schema, readers_schema
             )

--- a/lang/py/avro/schema.py
+++ b/lang/py/avro/schema.py
@@ -587,6 +587,15 @@ class EnumSchema(EqualByPropsMixin, NamedSchema):
             return symbols
         raise Exception
 
+    @property
+    def default(self) -> Union[str, None]:
+        symbol = self.get_prop("default")
+        if isinstance(symbol, str):
+            return symbol
+        if symbol is None:
+            return None
+        raise Exception
+
     doc = property(lambda self: self.get_prop("doc"))
 
     def match(self, writer):

--- a/lang/py/avro/test/test_io.py
+++ b/lang/py/avro/test/test_io.py
@@ -645,6 +645,116 @@ class TestMisc(unittest.TestCase):
         with self.assertRaisesRegex(avro.errors.AvroTypeException, r"The datum \".*\" provided for \".*\" is not an example of the schema [\s\S]*"):
             write_datum(datum_to_write, writers_schema)
 
+    def test_can_read_future_enum_symbol_with_default(self) -> None:
+        default_symbol = "unknown"
+        future_symbol = "crc32_be"
+
+        readers_schema = avro.schema.parse(
+            json.dumps(
+                {
+                    "fields": [
+                        {
+                            "name": "checksum_algorithm",
+                            "type": {
+                                "name": "ChecksumAlgorithm",
+                                "symbols": [default_symbol, "xxhash3_64_be"],
+                                "type": "enum",
+                                "default": default_symbol,
+                            },
+                        },
+                    ],
+                    "name": "Test",
+                    "type": "record",
+                }
+            )
+        )
+        # Writer adds the "crc32_be" symbol.
+        writers_schema = avro.schema.parse(
+            json.dumps(
+                {
+                    "fields": [
+                        {
+                            "name": "checksum_algorithm",
+                            "type": {
+                                "name": "ChecksumAlgorithm",
+                                "symbols": [
+                                    "unknown",
+                                    "xxhash3_64_be",
+                                    future_symbol,
+                                ],
+                                "type": "enum",
+                                "default": default_symbol,
+                            },
+                        }
+                    ],
+                    "name": "Test",
+                    "type": "record",
+                }
+            )
+        )
+
+        datum_to_write = {"checksum_algorithm": future_symbol}
+
+        buffer, encoder, datum_writer = write_datum(datum_to_write, writers_schema)
+        buffer.seek(0)
+        decoder = avro.io.BinaryDecoder(buffer)
+        reader = avro.io.DatumReader(readers_schema)
+        datum_read = reader.read(decoder)
+        self.assertEqual(datum_read, {"checksum_algorithm": default_symbol})
+
+    def test_raises_error_for_future_enum_symbol_without_default(self) -> None:
+        future_symbol = "crc32_be"
+
+        readers_schema = avro.schema.parse(
+            json.dumps(
+                {
+                    "fields": [
+                        {
+                            "name": "checksum_algorithm",
+                            "type": {
+                                "name": "ChecksumAlgorithm",
+                                "symbols": ["xxhash3_64_be"],
+                                "type": "enum",
+                            },
+                        },
+                    ],
+                    "name": "Test",
+                    "type": "record",
+                }
+            )
+        )
+        # Writer adds the "crc32_be" symbol.
+        writers_schema = avro.schema.parse(
+            json.dumps(
+                {
+                    "fields": [
+                        {
+                            "name": "checksum_algorithm",
+                            "type": {
+                                "name": "ChecksumAlgorithm",
+                                "symbols": [
+                                    "xxhash3_64_be",
+                                    future_symbol,
+                                ],
+                                "type": "enum",
+                            },
+                        }
+                    ],
+                    "name": "Test",
+                    "type": "record",
+                }
+            )
+        )
+
+        datum_to_write = {"checksum_algorithm": future_symbol}
+
+        buffer, encoder, datum_writer = write_datum(datum_to_write, writers_schema)
+        buffer.seek(0)
+        decoder = avro.io.BinaryDecoder(buffer)
+        reader = avro.io.DatumReader(readers_schema)
+        with self.assertRaises(avro.errors.SchemaResolutionException):
+            reader.read(decoder)
+
 
 def load_tests(loader: unittest.TestLoader, default_tests: None, pattern: None) -> unittest.TestSuite:
     """Generate test cases across many test schema."""


### PR DESCRIPTION
See https://github.com/apache/avro/pull/2250.